### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    investec_open_api (2.1.0)
+    investec_open_api (2.2.0)
       base64
       faraday
       money

--- a/lib/investec_open_api/version.rb
+++ b/lib/investec_open_api/version.rb
@@ -1,3 +1,3 @@
 module InvestecOpenApi
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
This PR updates the gem version to 2.2.0 and includes Gemfile.lock update. All tests still pass. 